### PR TITLE
fix: correct default location prop type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ MockRouter.childContextTypes = {
 
 MockRouter.defaultProps = {
   url: '',
-  location: '',
+  location: {},
   params: {},
   path: '',
   createHref: noop,


### PR DESCRIPTION
Resolves: https://github.com/rkoeze/react-mock-router/issues/4

* Corrects default prop for location was `''` now `{}`